### PR TITLE
Remove safety check on field_name method presence

### DIFF
--- a/lib/pivot_table/grid.rb
+++ b/lib/pivot_table/grid.rb
@@ -82,8 +82,7 @@ module PivotTable
         current_row = []
         column_headers.each_with_index do |col, col_index|
           object = @source_data.find { |item| access_record(item, row_name) == row && access_record(item, column_name) == col }
-          has_field_name = field_name && object.respond_to?(field_name)
-          current_row[col_index] = has_field_name ? access_record(object, field_name) : object
+          current_row[col_index] = field_name ? access_record(object, field_name) : object
         end
         @data_grid[row_index] = current_row
       end

--- a/spec/pivot_table/grid_spec.rb
+++ b/spec/pivot_table/grid_spec.rb
@@ -153,7 +153,7 @@ module PivotTable
 
         let(:build_result) { instance.build }
         subject { build_result.data_grid }
-        it { should == [[d1, d2, d3], [d4, d5, d6]] }
+        it { should == [[nil, nil, nil], [nil, nil, nil]] }
       end
     end
   end


### PR DESCRIPTION
If a user provides a bad field_name, it can return no data for that bad
field name. This is in line with how the rest of the configuration
options work, which do not get error-checked.